### PR TITLE
Reduces post count to prevent timeouts

### DIFF
--- a/includes/endpoints/class-mmt-rest-posts-controller.php
+++ b/includes/endpoints/class-mmt-rest-posts-controller.php
@@ -217,7 +217,7 @@ class MMT_REST_Posts_Controller extends MMT_REST_Controller {
 
 		add_filter( 'xmlrpc_enabled', '__return_false' );
 
-		$data = MMT_API::get_data( 'posts', ['timeout' => 40 ], $request->get_body_params() );
+		$data = MMT_API::get_data( 'posts', ['timeout' => 180 ], $request->get_body_params() );
 
 		// setup url video swapping
 		$current_site_url = get_site_url();

--- a/includes/wizard/class-mmt-wizard.php
+++ b/includes/wizard/class-mmt-wizard.php
@@ -430,7 +430,7 @@ class MMT_Wizard {
 					'batch' => array(
 						'route'  => $_GET['step'] . '/batch',
 						'method' => 'POST',
-						'per_page' => ( 'media' == $_GET['step'] ? 75 : 100 ),
+						'per_page' => ( 'media' == $_GET['step'] ? 75 : 80 ),
 					),
 				),
 			)


### PR DESCRIPTION
Earlier commits changed the featured image lookup from equals to like, which slows down post processing. Adjusting the per batch amount alleviates that.